### PR TITLE
Adjust brillanteseguro project tag ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,13 +228,13 @@
                     <div class="project-content">
                         <h3>brillanteseguro.es</h3>
                         <p>Platform I developed for free for my neighborhood community where residents can visualize incidents on a map, including security alerts, public road issues, and lost pets, while also accessing a marketplace to offer professional services or second-hand products.</p>
+                        <p>It also includes an incident management dashboard for community administrators so they can review, prioritize, and coordinate responses efficiently.</p>
                         <div class="project-tech">
                             <span>Community Platform</span>
                             <span>Interactive Maps</span>
                             <span>Marketplace</span>
                             <span>Admin Panel</span>
                         </div>
-                        <p>It also includes an incident management dashboard for community administrators so they can review, prioritize, and coordinate responses efficiently.</p>
                         <div class="project-links">
                             <a href="https://brillanteseguro.es" target="_blank" class="btn small">Website</a>
                         </div>


### PR DESCRIPTION
### Motivation
- Ensure the tech tags for the `brillanteseguro.es` project card render after the full description so they do not interrupt the text.

### Description
- Moved the `<div class="project-tech">` block below the final description paragraph in `index.html` to change the visual/reading order.

### Testing
- Verified the markup change with `git diff -- index.html` and inspected the updated lines using `nl -ba index.html | sed -n '224,242p'`, both confirming the reorder.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7f615fec832c913cdb0255a90fe1)